### PR TITLE
Rewrote jquery parts to vanilla js

### DIFF
--- a/src/ajaxOptOut.js
+++ b/src/ajaxOptOut.js
@@ -1,16 +1,16 @@
 window.onload = function () {
-    var checkbox = $('#piwikOptOutCheckbox');
-    var piwikOptOutText = $('#piwikOptOutText');
+    var checkbox = document.querySelector('#piwikOptOutCheckbox');
+    var piwikOptOutText = document.querySelector('#piwikOptOutText');
 
     var piwikOptOutOn = '<?= l::get('ka.piwik.trackOn'); ?>';
     var piwikOptOutOff = '<?= l::get('ka.piwik.trackOff'); ?>';
 
     ajax('isTracked', function (response) {
         showText(response.value);
-        checkbox.prop('checked', response.value);
+        checkbox.checked = response.value;
     });
 
-    checkbox.click(function () {
+    checkbox.onclick = function () {
         if (this.checked == true) {
             ajax('doTrack');
         } else {
@@ -18,26 +18,38 @@ window.onload = function () {
         }
 
         showText(this.checked);
-    });
+    };
 
     function showText(state) {
         if (state == true) {
-            piwikOptOutText.html(piwikOptOutOn);
+            piwikOptOutText.innerHTML = piwikOptOutOn;
         } else {
-            piwikOptOutText.html(piwikOptOutOff);
+            piwikOptOutText.innerHTML = piwikOptOutOff;
         }
-    }
+    };
 
-    function ajax(api, ok) {
-        $.ajax({
-            url: '<?= $url; ?>/index.php?module=API&method=AjaxOptOut.' + api + '&format=json',
-            jsonp: 'callback',
-            dataType: 'jsonp',
-            contentType: 'application/json',
-            success: ok,
-            error: function (error) {
-                console.log(error);
-            }
-        });
-    }
+    // Based on: https://gist.github.com/gf3/132080
+    function ajax(api, callback) {
+        var url = '<?= $url; ?>/index.php?module=API&method=AjaxOptOut.' + api + '&format=json';
+        var unique =  Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+        // INIT
+        var name = "_jsonp_" + unique;
+        if (url.match(/\?/)) url += "&callback="+name;
+        else url += "?callback="+name;
+
+        // Create script
+        var script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.src = url;
+
+        // Setup handler
+        window[name] = function(data){
+            if(callback != undefined) callback.call(window, data);
+            document.getElementsByTagName('head')[0].removeChild(script);
+            delete window[name];
+        };
+
+        // Load JSON
+        document.getElementsByTagName('head')[0].appendChild(script);
+    };
 };

--- a/templates/ajaxOptOut.php
+++ b/templates/ajaxOptOut.php
@@ -4,7 +4,6 @@
     <input type="checkbox" id="piwikOptOutCheckbox">
     <span id="piwikOptOutText"></span>
 </label>
-
 <script>
-    window.onload=function(){function e(a){1==a?b.html(c):b.html(d)}function f(a,b){$.ajax({url:"<?= $url; ?>/index.php?module=API&method=AjaxOptOut."+a+"&format=json",jsonp:"callback",dataType:"jsonp",contentType:"application/json",success:b,error:function(a){console.log(a)}})}var a=$("#piwikOptOutCheckbox"),b=$("#piwikOptOutText"),c="<?= l::get('ka.piwik.trackOn'); ?>",d="<?= l::get('ka.piwik.trackOff'); ?>";f("isTracked",function(b){e(b.value),a.prop("checked",b.value)}),a.click(function(){f(1==this.checked?"doTrack":"doIgnore"),e(this.checked)})};
+    window.onload=function(){var e=document.querySelector("#piwikOptOutCheckbox"),o=document.querySelector("#piwikOptOutText"),t="<?= l::get('ka.piwik.trackOn'); ?>",n="<?= l::get('ka.piwik.trackOff'); ?>";function c(e){o.innerHTML=1==e?t:n}function a(e,o){var t="<?= $url; ?>/index.php?module=API&method=AjaxOptOut."+e+"&format=json",n=Math.floor(65536*(1+Math.random())).toString(16).substring(1);var c="_jsonp_"+n;t.match(/\?/)?t+="&callback="+c:t+="?callback="+c;var a=document.createElement("script");a.type="text/javascript",a.src=t,window[c]=function(e){void 0!=o&&o.call(window,e),document.getElementsByTagName("head")[0].removeChild(a),delete window[c]},document.getElementsByTagName("head")[0].appendChild(a)}a("isTracked",function(o){c(o.value),e.checked=o.value}),e.onclick=function(){1==this.checked?a("doTrack"):a("doIgnore"),c(this.checked)}};
 </script>


### PR DESCRIPTION
Until now the plug-in had a jquery dependency. This unnecessarily restricted the number of users to those who use jquery on their site.

I rewrote the parts that relied on jquery to plain javascript opening up the plug-in to everyone. 

The plugin is slightly bigger now - but still very lightweight. I think it's a good balance.